### PR TITLE
make sure that login view presented on top of rootviewcontroller

### DIFF
--- a/source/Assets/Plugins/iOS/TwitterKitIOSWrapper.mm
+++ b/source/Assets/Plugins/iOS/TwitterKitIOSWrapper.mm
@@ -151,7 +151,8 @@ void TwitterInit(const char *consumerKey, const char *consumerSecret)
  */
 void TwitterLogIn()
 {
-   [[Twitter sharedInstance] logInWithCompletion:^(TWTRSession *session, NSError *error) {
+    UIViewController *rootViewController = [[[UIApplication sharedApplication] keyWindow] rootViewController];
+   [[Twitter sharedInstance] logInWithViewController:rootViewController completion:^(TWTRSession *session, NSError *error) {
        if (session) {
             NSDictionary *sessionDictionary = NSDictionaryFromTWTRSession(session);
             char *serializedSession = serializedJSONFromNSDictionary(sessionDictionary);


### PR DESCRIPTION
Hi,

Similarly to `TwitterCompose` method, `TwitterLoginMethod` should call the native method with the current rootviewcontroller to avoid non properly displayed views.

Thanks,
Gabor