### PR TITLE
add required dependency

### DIFF
--- a/source/Assets/Twitter/Editor/TwitterPostProcess.cs
+++ b/source/Assets/Twitter/Editor/TwitterPostProcess.cs
@@ -43,6 +43,14 @@ public class TwitterPostProcessBuild {
 				return;
 			}
 
+			// Add SafariServices.framework to Link Binary With Libraries section           
+			var pbxprojPath = PBXProject.GetPBXProjectPath(pathToBuiltProject);
+			var project = new PBXProject();
+			project.ReadFromString(File.ReadAllText(pbxprojPath));
+			var target = project.TargetGuidByName(PBXProject.GetUnityTargetName());
+			project.AddFrameworkToProject(target, "SafariServices.framework", false);
+			File.WriteAllText(pbxprojPath, project.WriteToString());
+
 			// Get plist
 			string plistPath = pathToBuiltProject + "/Info.plist";
 			PlistDocument plist = new PlistDocument();


### PR DESCRIPTION
add SafariServices.framework to build target to avoid build failures in generated iOS project