### PR TITLE
Fix for the Twitter composerVC not displaying onscreen sometimes, and…

### DIFF
--- a/source/Assets/Plugins/iOS/TwitterKitIOSWrapper.mm
+++ b/source/Assets/Plugins/iOS/TwitterKitIOSWrapper.mm
@@ -26,6 +26,7 @@ static const char * TWTRUnityAPIMethodRequestEmailFailed = "RequestEmailFailed";
 static const char * TWTRUnityAPIMethodTweetComplete = "TweetComplete";
 static const char * TWTRUnityAPIMethodTweetFailed = "TweetFailed";
 static const char * TWTRUnityAPIMethodTweetCancelled = "TweetCancelled";
+UIViewController * UnityGetGLViewController();
 
 #pragma mark - String Helpers
 
@@ -221,7 +222,7 @@ void TwitterCompose(const char *userID, const char *imageURI, const char *text, 
     TWTRComposerViewController *composerVC = [[TWTRComposerViewController alloc] initWithInitialText:[NSString stringWithFormat:@"%@%@", NSStringFromCString(text), hashtagsString] image:image videoURL:nil];
     composerVC.delegate = TwitterUnityWrapper.sharedInstance;
     
-    [[[[UIApplication sharedApplication] keyWindow] rootViewController] presentViewController:composerVC animated:YES completion:nil];
+    [UnityGetGLViewController() presentViewController:composerVC animated:YES completion:nil];
 }
 
 /**


### PR DESCRIPTION
… failing silently. Now uses a Unity-approved method for retrieving the view controller to present on top of it.

Experienced this bug in Unity 2017.1.0p5, in the latest released TwitterKit for Unity version. Might have to do with us having subclassed UnityAppController, so the VC stack order is different. This minor fix appears to fix it in all cases.