### PR TITLE
fix error making asset bundle

### DIFF
--- a/source/Assets/Twitter/Scripts/Twitter.cs
+++ b/source/Assets/Twitter/Scripts/Twitter.cs
@@ -15,11 +15,11 @@
  *
  */
 namespace TwitterKit.Unity
-{	
+{
 	using UnityEngine;
 	using System;
 	using System.Collections.Generic;
-	using Internal;
+	using TwitterKit.Internal;
 	using TwitterKit.Unity.Settings;
 
 	public sealed class Twitter : ScriptableObject


### PR DESCRIPTION
I imported twitter kit unity to my unity project.
I made asset bundle.
Error occured.
```
error CS0246: The type or namespace name `EditorTwitterImpl' could not be found. Are you missing an assembly reference?
```

I fixed.
