### PR TITLE
Bugfix for authorization failure when screen orientation changes

### DIFF
--- a/Native/TwitterKitAndroidWrapper/app/src/main/AndroidManifest.xml
+++ b/Native/TwitterKitAndroidWrapper/app/src/main/AndroidManifest.xml
@@ -18,7 +18,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.twitter.sdk.android.unity">
     <application>
-        <activity android:name="com.twitter.sdk.android.unity.LoginActivity" android:configChanges="keyboardHidden|orientation"/>
+        <activity android:name="com.twitter.sdk.android.unity.LoginActivity" android:configChanges="keyboardHidden|orientation|screenSize"/>
         <receiver
             android:name="com.twitter.sdk.android.unity.TweetReceiver"
             android:exported="false">

--- a/Native/TwitterKitAndroidWrapper/app/src/main/AndroidManifest.xml
+++ b/Native/TwitterKitAndroidWrapper/app/src/main/AndroidManifest.xml
@@ -18,7 +18,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.twitter.sdk.android.unity">
     <application>
-        <activity android:name="com.twitter.sdk.android.unity.LoginActivity"/>
+        <activity android:name="com.twitter.sdk.android.unity.LoginActivity" android:configChanges="keyboardHidden|orientation"/>
         <receiver
             android:name="com.twitter.sdk.android.unity.TweetReceiver"
             android:exported="false">

--- a/Native/TwitterKitAndroidWrapper/app/src/main/java/com/twitter/sdk/android/unity/LoginActivity.java
+++ b/Native/TwitterKitAndroidWrapper/app/src/main/java/com/twitter/sdk/android/unity/LoginActivity.java
@@ -60,6 +60,7 @@ public class LoginActivity extends Activity {
                         .setData(error)
                         .build();
                 message.send();
+                authClient.cancelAuthorize();
                 finish();
             }
         });

--- a/Native/TwitterKitAndroidWrapper/app/src/main/java/com/twitter/sdk/android/unity/LoginActivity.java
+++ b/Native/TwitterKitAndroidWrapper/app/src/main/java/com/twitter/sdk/android/unity/LoginActivity.java
@@ -33,6 +33,7 @@ import com.twitter.sdk.android.core.identity.TwitterAuthClient;
  */
 public class LoginActivity extends Activity {
     TwitterAuthClient authClient;
+    boolean didReceiveActivityResult = false;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -69,7 +70,17 @@ public class LoginActivity extends Activity {
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
-
+        didReceiveActivityResult = true;
         authClient.onActivityResult(requestCode, resultCode, data);
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        if(!didReceiveActivityResult)
+        {
+            didReceiveActivityResult = true;
+            authClient.onActivityResult(authClient.getRequestCode(), RESULT_CANCELED, null);
+        }
     }
 }


### PR DESCRIPTION
If twitter app is not installed and your unity app is in landscape mode, If LoginActivity rotates, this will cause onCreate() be called twice and result in 'Authorize already in progress' error. 
So a smiple manifest change can fix this.

And during the test I noticed that once login flow fails, authState is not cleaned up. So I added a line to fix this.

